### PR TITLE
 Extract fixed columns and refactor expressions to AST

### DIFF
--- a/halo2_proofs/Cargo.toml
+++ b/halo2_proofs/Cargo.toml
@@ -56,6 +56,7 @@ blake2b_simd = "1"
 # Developer tooling dependencies
 plotters = { version = "0.3.0", optional = true }
 tabbycat = { version = "0.1", features = ["attributes"], optional = true }
+cbor = "0.4.1"
 
 [dev-dependencies]
 assert_matches = "1.5"

--- a/halo2_proofs/src/dev/ir.rs
+++ b/halo2_proofs/src/dev/ir.rs
@@ -18,121 +18,162 @@
 // ]
 
 use super::util;
-use crate::plonk::{Circuit, ConstraintSystem};
-use ff::PrimeField;
+use crate::circuit::Value;
+use crate::plonk::{
+    Advice, Any, Assigned, Assignment, Circuit, Column, ColumnType, ConstraintSystem, Error, Fixed,
+    FloorPlanner, Instance, Selector,
+};
+use crate::poly::Rotation;
+use ff::Field;
+use pasta_curves::arithmetic::FieldExt;
 use std::collections::HashMap;
 use std::fmt;
+use std::io;
+use std::ops::Index;
+use std::slice::SliceIndex;
 
 #[derive(Debug)]
-pub struct Constraint {
-    name: &'static str,
-    expression: String,
+pub enum Polynomial<F: Field> {
+    Var(Variable),
+    Scalar(F),
+    Neg(Box<Polynomial<F>>),
+    Add(Box<Polynomial<F>>, Box<Polynomial<F>>),
+    Mul(Box<Polynomial<F>>, Box<Polynomial<F>>),
 }
 
 #[derive(Debug)]
-pub struct Gate {
+pub struct Constraint<F: Field> {
     name: &'static str,
-    constraints: Vec<Constraint>,
+    expression: Polynomial<F>,
 }
 
+#[derive(Debug)]
+pub struct Gate<F: Field> {
+    name: &'static str,
+    constraints: Vec<Constraint<F>>,
+}
+#[derive(Debug)]
 pub struct Variable {
     index: usize,
-    col_type: ColType,
-}
-
-impl Variable {
-    /// key = (col_type, column_index, rotation)
-    /// rotation is always `0` for selector column
-    fn key(&self) -> (usize, usize, i32) {
-        match self.col_type {
-            ColType::Advice(c_i, r) => (0, c_i, r),
-            ColType::Fixed(c_i, r) => (1, c_i, r),
-            ColType::Instance(c_i, r) => (2, c_i, r),
-            ColType::Selector(c_i) => (3, c_i, 0),
-        }
-    }
+    col_type: Any,
 }
 
 impl fmt::Display for Variable {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.col_type {
-            ColType::Advice(c_i, r) => write!(f, "A{}", self.index),
-            ColType::Fixed(c_i, r) => write!(f, "F{}", self.index),
-            ColType::Instance(c_i, r) => write!(f, "I{}", self.index),
-            ColType::Selector(c_i) => write!(f, "S{}", self.index),
+            Any::Advice => write!(f, "A{}", self.index),
+            Any::Fixed => write!(f, "F{}", self.index),
+            Any::Instance => write!(f, "I{}", self.index),
         }
     }
 }
 
-pub enum ColType {
-    Advice(usize, i32),
-    Fixed(usize, i32),
-    Instance(usize, i32),
-    Selector(usize),
+impl<F: Field> fmt::Display for Polynomial<F> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Var(v) => write!(f, "{}", v),
+            Self::Scalar(v) => write!(f, "{}", &util::format_value(*v)),
+            Self::Neg(x) => write!(f, "-{}", x),
+            Self::Add(x, y) => match &**y {
+                Self::Neg(y) => write!(f, "({} - {})", x, y),
+                _ => write!(f, "({} + {})", x, y),
+            },
+            Self::Mul(x, y) => write!(f, "({} * {})", x, y),
+        }
+    }
+}
+
+impl<F: Field> fmt::Display for Constraint<F> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.name.is_empty() {
+            write!(f, "{}", self.expression)
+        } else {
+            write!(f, "{}: {}", self.name, self.expression)
+        }
+    }
+}
+
+impl<F: Field> fmt::Display for Gate<F> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.name.is_empty() {
+            write!(f, "[")?
+        } else {
+            write!(f, "{}: [", self.name)?
+        }
+        for c in &self.constraints {
+            write!(f, "{}, ", c)?
+        }
+        write!(f, "]")
+    }
 }
 
 /// IR struct
 #[derive(Debug)]
-pub struct Ir {}
+pub struct Ir<F: Field> {
+    k: u32,
+    num_rows: usize,
+    fixed: Vec<Vec<F>>,
+    selectors: Vec<Vec<bool>>,
+    equality: Vec<(Column<Any>, usize, Column<Any>, usize)>,
+    constraints: Vec<Constraint<F>>,
+    // Start of selector fixed columns
+    selector_index: usize,
+}
 
-impl Ir {
+fn query_index<'a, C, I>(queries: I, column: usize, rotation: Rotation) -> usize
+where
+    C: ColumnType,
+    I: IntoIterator<Item = &'a (Column<C>, Rotation)>,
+{
+    queries
+        .into_iter()
+        .position(|(col, rot)| col.index() == column && *rot == rotation)
+        .unwrap()
+}
+
+impl<F: FieldExt> Ir<F> {
+    fn new(k: u32, num_fixed: usize, num_selectors: usize) -> Self {
+        let num_rows = 1 << k;
+        Self {
+            k,
+            num_rows,
+            fixed: vec![vec![F::default(); num_rows]; num_fixed],
+            selectors: vec![vec![false; num_rows]; num_selectors],
+            equality: vec![],
+            constraints: vec![],
+            selector_index: num_fixed,
+        }
+    }
+
     /// Collects gates
-    pub fn collect<F: PrimeField, C: Circuit<F>>() -> Vec<Gate> {
+    pub fn write<ConcreteCircuit: Circuit<F>>(
+        k: u32,
+        circuit: &ConcreteCircuit,
+        compress: bool,
+        outfile: impl io::Write,
+    ) {
         let mut cs = ConstraintSystem::default();
-        let _ = C::configure(&mut cs);
-        let cs = cs;
+        let config = ConcreteCircuit::configure(&mut cs);
+        let mut ir = Ir::new(k, cs.num_fixed_columns, cs.num_selectors);
+        ConcreteCircuit::FloorPlanner::synthesize(&mut ir, circuit, config, cs.constants.clone())
+            .unwrap();
 
-        // Creates a hashmap with all `Variable`s
-        let variables_vec = cs.gates.iter().flat_map(|gate| {
-            gate.polynomials().iter().flat_map(|c| {
-                c.evaluate(
-                    &|_| vec![],
-                    &|selector| {
-                        vec![Variable {
-                            index: 0,
-                            col_type: ColType::Selector(selector.0),
-                        }]
-                    },
-                    &|_, column, rotation| {
-                        vec![Variable {
-                            index: 0,
-                            col_type: ColType::Fixed(column, rotation.0),
-                        }]
-                    },
-                    &|_, column, rotation| {
-                        vec![Variable {
-                            index: 0,
-                            col_type: ColType::Advice(column, rotation.0),
-                        }]
-                    },
-                    &|_, column, rotation| {
-                        vec![Variable {
-                            index: 0,
-                            col_type: ColType::Instance(column, rotation.0),
-                        }]
-                    },
-                    &|a| a,
-                    &|mut a, mut b| {
-                        a.append(&mut b);
-                        a
-                    },
-                    &|mut a, mut b| {
-                        a.append(&mut b);
-                        a
-                    },
-                    &|a, _| a,
-                )
-            })
-        });
-        let mut variables_map = HashMap::new();
-        let mut index: usize = 0;
-        variables_vec.for_each(|v| {
-            let v = variables_map.entry(v.key()).or_insert(v);
-            v.index = index;
-            index += 1;
-        });
+        if compress {
+            let (cs_compressed, selector_polys) = cs.compress_selectors(ir.selectors);
+            assert!(cs_compressed.num_fixed_columns == ir.selector_index + selector_polys.len());
+            cs = cs_compressed;
+            ir.fixed.extend(selector_polys)
+        } else {
+            ir.fixed.extend(
+                ir.selectors
+                    .iter()
+                    .map(|r| r.iter().map(|&s| F::from_u128(s as u128)).collect())
+                    .collect::<Vec<_>>(),
+            );
+        }
+    }
 
-        // Collect all gates
+    fn collect_gates(&mut self, cs: ConstraintSystem<F>) -> Vec<Gate<F>> {
         cs.gates
             .iter()
             .map(|gate| Gate {
@@ -144,71 +185,153 @@ impl Ir {
                     .map(|(i, constraint)| Constraint {
                         name: gate.constraint_name(i),
                         expression: constraint.evaluate(
-                            &util::format_value,
+                            &Polynomial::Scalar,
                             &|selector| {
-                                format!(
-                                    "{}",
-                                    variables_map
-                                        .get(&(3, selector.0, 0))
-                                        .expect("Var key exists")
-                                )
+                                Polynomial::Var(Variable {
+                                    index: selector.0 + cs.fixed_queries.len(),
+                                    col_type: Any::Fixed,
+                                })
                             },
                             &|_, column, rotation| {
-                                format!(
-                                    "{}",
-                                    variables_map
-                                        .get(&(1, column, rotation.0))
-                                        .expect("Var key exists")
-                                )
+                                let index = query_index(&cs.fixed_queries, column, rotation);
+                                Polynomial::Var(Variable {
+                                    index,
+                                    col_type: Any::Fixed,
+                                })
                             },
                             &|_, column, rotation| {
-                                format!(
-                                    "{}",
-                                    variables_map
-                                        .get(&(0, column, rotation.0))
-                                        .expect("Var key exists")
-                                )
+                                let index = query_index(&cs.advice_queries, column, rotation);
+                                Polynomial::Var(Variable {
+                                    index,
+                                    col_type: Any::Advice,
+                                })
                             },
                             &|_, column, rotation| {
-                                format!(
-                                    "{}",
-                                    variables_map
-                                        .get(&(2, column, rotation.0))
-                                        .expect("Var key exists")
-                                )
+                                let index = query_index(&cs.instance_queries, column, rotation);
+                                Polynomial::Var(Variable {
+                                    index,
+                                    col_type: Any::Instance,
+                                })
                             },
-                            &|a| {
-                                if a.contains(' ') {
-                                    format!("-({})", a)
-                                } else {
-                                    format!("-{}", a)
-                                }
-                            },
-                            &|a, b| {
-                                if let Some(b) = b.strip_prefix('-') {
-                                    format!("{} - {}", a, b)
-                                } else {
-                                    format!("{} + {}", a, b)
-                                }
-                            },
-                            &|a, b| match (a.contains(' '), b.contains(' ')) {
-                                (false, false) => format!("{} * {}", a, b),
-                                (false, true) => format!("{} * ({})", a, b),
-                                (true, false) => format!("({}) * {}", a, b),
-                                (true, true) => format!("({}) * ({})", a, b),
-                            },
-                            &|a, s| {
-                                if a.contains(' ') {
-                                    format!("({}) * {}", a, util::format_value(s))
-                                } else {
-                                    format!("{} * {}", a, util::format_value(s))
-                                }
-                            },
+                            &|x| Polynomial::Neg(Box::new(x)),
+                            &|x, y| Polynomial::Add(Box::new(x), Box::new(y)),
+                            &|x, y| Polynomial::Mul(Box::new(x), Box::new(y)),
+                            &|a, s| Polynomial::Mul(Box::new(Polynomial::Scalar(s)), Box::new(a)),
                         ),
                     })
                     .collect(),
             })
             .collect()
+    }
+}
+
+impl<F: Field> Assignment<F> for Ir<F> {
+    fn enter_region<NR, N>(&mut self, _name_fn: N)
+    where
+        NR: Into<String>,
+        N: FnOnce() -> NR,
+    {
+        // TODO: Regions
+    }
+
+    fn exit_region(&mut self) {
+        //TODO
+    }
+
+    fn enable_selector<A, AR>(
+        &mut self,
+        _annotation: A,
+        selector: &Selector,
+        row: usize,
+    ) -> Result<(), Error>
+    where
+        A: FnOnce() -> AR,
+        AR: Into<String>,
+    {
+        if let Some(cell) = self.selectors[selector.0].get_mut(row) {
+            *cell = true;
+        } else {
+            return Err(Error::not_enough_rows_available(self.k));
+        };
+        Ok(())
+    }
+
+    fn query_instance(&self, _column: Column<Instance>, _row: usize) -> Result<Value<F>, Error> {
+        Ok(Value::unknown())
+    }
+
+    fn assign_advice<V, VR, A, AR>(
+        &mut self,
+        _annotation: A,
+        _column: Column<Advice>,
+        _row: usize,
+        _: V,
+    ) -> Result<(), Error>
+    where
+        V: FnOnce() -> crate::circuit::Value<VR>,
+        VR: Into<crate::plonk::Assigned<F>>,
+        A: FnOnce() -> AR,
+        AR: Into<String>,
+    {
+        Ok(())
+    }
+
+    fn assign_fixed<V, VR, A, AR>(
+        &mut self,
+        _annotation: A,
+        column: Column<Fixed>,
+        row: usize,
+        to: V,
+    ) -> Result<(), Error>
+    where
+        V: FnOnce() -> Value<VR>,
+        VR: Into<crate::plonk::Assigned<F>>,
+        A: FnOnce() -> AR,
+        AR: Into<String>,
+    {
+        let cell = self
+            .fixed
+            .get_mut(column.index())
+            .and_then(|v| v.get_mut(row))
+            .ok_or(Error::BoundsFailure)?;
+        *cell = to().into_field().evaluate().assign()?;
+        Ok(())
+    }
+
+    fn copy(
+        &mut self,
+        left_column: Column<Any>,
+        left_row: usize,
+        right_column: Column<Any>,
+        right_row: usize,
+    ) -> Result<(), Error> {
+        self.equality
+            .push((left_column, left_row, right_column, right_row));
+        Ok(())
+    }
+
+    fn fill_from_row(
+        &mut self,
+        column: Column<Fixed>,
+        row: usize,
+        to: Value<Assigned<F>>,
+    ) -> Result<(), Error> {
+        for row in row..self.num_rows {
+            self.assign_fixed(|| "", column, row, || to)?;
+        }
+        Ok(())
+    }
+
+    fn push_namespace<NR, N>(&mut self, _name_fn: N)
+    where
+        NR: Into<String>,
+        N: FnOnce() -> NR,
+    {
+        //TODO?
+    }
+
+    fn pop_namespace(&mut self, _gadget_name: Option<String>) {
+        //TODO?
     }
 }
 
@@ -241,6 +364,7 @@ mod tests {
             let a = meta.advice_column();
             let b = meta.advice_column();
             let c = meta.advice_column();
+            let f = meta.fixed_column();
             let q1 = meta.selector();
             let q2 = meta.selector();
 
@@ -250,7 +374,7 @@ mod tests {
                 let c = meta.query_advice(c, Rotation::cur());
                 let q1 = meta.query_selector(q1);
 
-                Some(("trial constraint", q1 * ((a + b) - c)))
+                Some(("trial constraint1", q1 * ((a + b) - c)))
             });
 
             meta.create_gate("Trial2", |meta| {
@@ -258,7 +382,17 @@ mod tests {
                 let b = meta.query_advice(b, Rotation::cur());
                 let q2 = meta.query_selector(q2);
 
-                Some(("trial constraint", q2 * (a + b)))
+                Some(("trial constraint2", q2 * (a + b)))
+            });
+
+            meta.create_gate("Trial3", |meta| {
+                let a = meta.query_advice(a, Rotation::next());
+                let b = meta.query_advice(b, Rotation::cur());
+                let f = meta.query_fixed(f, Rotation::next());
+                let q1 = meta.query_selector(q1);
+                let q2 = meta.query_selector(q2);
+
+                vec![q1 * (a.clone() * (a + b.clone())), q2 * (b + f)]
             });
 
             MyConfig {}
@@ -275,7 +409,12 @@ mod tests {
 
     #[test]
     fn test1() {
-        let gates = Ir::collect::<pallas::Base, MyCircuit>();
-        print!("{:?}", gates);
+        let mut cs = ConstraintSystem::<pallas::Base>::default();
+        let _ = MyCircuit::configure(&mut cs);
+        let mut ir = Ir::new(2, cs.num_fixed_columns, cs.num_selectors);
+        let gates = ir.collect_gates(cs);
+        for gate in gates {
+            println!("{}", gate);
+        }
     }
 }


### PR DESCRIPTION
I also changed the structure to no longer track variable indices and instead just store variables as (column_type, column_number, row_offset) because it seems to simplify things a good deal.

This change was introduced in the second commit, if you think we should keep the variable-dictionary approach then we can revert to the previous. It has some complications with selectors, however, since the selectors turn into Fixed columns late in the process.